### PR TITLE
Fix typos in readme and platform files

### DIFF
--- a/config_readme.md
+++ b/config_readme.md
@@ -106,9 +106,9 @@ roles = admin
 
 #### Data Source Platforms
 DashMachine includes several different 'platforms' for displaying data on your dash applications.
-Platforms are essentially plugins. All data source config entries require the `plaform` variable,
+Platforms are essentially plugins. All data source config entries require the `platform` variable,
 which tells DashMachine which platform file in the platform folder to load. **Note:** you are able to
-load your own plaform files by placing them in the platform folder and referencing them in the config.
+load your own platform files by placing them in the platform folder and referencing them in the config.
 However currently they will be deleted if you update the application, if you would like to make them
 permanent, submit a pull request for it to be added by default!
 

--- a/dashmachine/platform/deluge.py
+++ b/dashmachine/platform/deluge.py
@@ -14,7 +14,7 @@ password = MySecretPassword
 | Variable        | Required | Description                                                     | Options           |
 |-----------------|----------|-----------------------------------------------------------------|-------------------|
 | [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
-| plaform         | Yes      | Name of the platform.                                           | rest              |
+| platform        | Yes      | Name of the platform.                                           | rest              |
 | resource        | Yes      | Url of your deluge instance + '/json'                           | url               |
 | value_template  | Yes      | Jinja template for how the returned data from api is displayed. | jinja template    |
 | password        | No       | Password to use for auth.                                       | string            |

--- a/dashmachine/platform/ping.py
+++ b/dashmachine/platform/ping.py
@@ -12,7 +12,7 @@ resource = 192.168.1.1
 | Variable        | Required | Description                                                     | Options           |
 |-----------------|----------|-----------------------------------------------------------------|-------------------|
 | [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
-| plaform         | Yes      | Name of the platform.                                           | rest              |
+| platform        | Yes      | Name of the platform.                                           | rest              |
 | resource        | Yes      | Url of whatever you want to ping                                | url               |
 
 

--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -18,7 +18,7 @@ payload = {"var1": "hi", "var2": 1}
 | Variable        | Required | Description                                                     | Options           |
 |-----------------|----------|-----------------------------------------------------------------|-------------------|
 | [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
-| plaform         | Yes      | Name of the platform.                                           | rest              |
+| platform        | Yes      | Name of the platform.                                           | rest              |
 | resource        | Yes      | Url of rest api resource.                                       | url               |
 | value_template  | Yes      | Jinja template for how the returned data from api is displayed. | jinja template    |
 | method          | No       | Method for the api call, default is GET                         | GET,POST          |


### PR DESCRIPTION
In the config_readme and several of the platform files, the variable `platform` was specified as `plaform` which could cause confusion to users.  Corrected occurrences of this.