### PR TITLE
Add documentation for Transmission and PiHole platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # DashMachine
 ### Another web application bookmark dashboard, with fun features.
 
+## Before Installing
+Please read the latest update post: https://redd.it/flubzn
+
 ![screenshot](https://raw.githubusercontent.com/rmountjoy92/DashMachine/master/screenshot1.png)
 
 ![screenshot](https://raw.githubusercontent.com/rmountjoy92/DashMachine/master/screenshot2.png)
@@ -46,7 +49,7 @@ Instructions are for linux.
 ```
 virtualenv --python=python3 DashMachineEnv
 cd DashMachineEnv && source bin/activate
-git clone https://git.wolf-house.net/ross/DashMachine.git
+git clone https://github.com/rmountjoy92/DashMachine.git
 cd DashMachine && pip install -r requirements.txt
 python3 run.py
 ```

--- a/dashmachine/platform/curl.py
+++ b/dashmachine/platform/curl.py
@@ -14,7 +14,7 @@ response_type = json
 | Variable        | Required | Description                                                     | Options           |
 |-----------------|----------|-----------------------------------------------------------------|-------------------|
 | [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
-| plaform         | Yes      | Name of the platform.                                           | curl              |
+| platform        | Yes      | Name of the platform.                                           | curl              |
 | resource        | Yes      | Url to curl                                                     | url               |
 | value_template  | Yes      | Jinja template for how the returned data from api is displayed. | jinja template    |
 | response_type   | No       | Response type. Use json if response is a JSON. Default is plain.| plain,json        |

--- a/dashmachine/platform/pihole.py
+++ b/dashmachine/platform/pihole.py
@@ -1,3 +1,58 @@
+"""
+
+##### PiHole
+Display information from the PiHole API
+```ini
+[variable_name]
+platform = pihole
+host = 192.168.1.101
+password = {{ PiHole password }}
+value_template = {{ value_template }}
+```
+> **Returns:** `value_template` as rendered string
+
+| Variable        | Required | Description                                                     | Options           |
+|-----------------|----------|-----------------------------------------------------------------|-------------------|
+| [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
+| platform        | Yes      | Name of the platform.                                           | pihole            |
+| host            | Yes      | Host of the PiHole                                              | host              |
+| password        | Yes      | Password for the PiHole                                         | password          |
+| value_template  | Yes      | Jinja template for how the returned data from API is displayed. | jinja template    |
+
+
+<br />
+###### **Available fields for value_template**
+
+* domain_count
+* queries
+* blocked
+* ads_percentage
+* unique_domains
+* forwarded
+* cached
+* total_clients
+* unique_clients
+* total_queries
+* gravity_last_updated
+
+> **Working example:**
+>```ini
+> [pihole-data]
+> platform = pihole
+> host = 192.168.1.101
+> password = password123
+> value_template = Ads Blocked Today: {{ blocked }}<br>Status: {{ status }}<br>Queries today: {{ queries }}
+>
+> [PiHole]
+> prefix = http://
+> url = 192.168.1.101
+> icon = static/images/apps/pihole.png
+> description = A black hole for Internet advertisements
+> open_in = new_tab
+> data_sources = pihole-data
+>```
+"""
+
 from flask import render_template_string
 
 

--- a/dashmachine/platform/transmission.py
+++ b/dashmachine/platform/transmission.py
@@ -1,3 +1,57 @@
+"""
+
+##### Transmission
+Display information from the Trasnmission API
+```ini
+[variable_name]
+platform = transmission
+host = localhost
+port = 9091
+user = {{ transmission Web UI username }}
+password = {{ Transmission Web UI password }}
+value_template = {{ value_template }}
+```
+> **Returns:** `value_template` as rendered string
+
+| Variable        | Required | Description                                                     | Options           |
+|-----------------|----------|-----------------------------------------------------------------|-------------------|
+| [variable_name] | Yes      | Name for the data source.                                       | [variable_name]   |
+| platform        | Yes      | Name of the platform.                                           | transmission      |
+| host            | Yes      | Host of Transmission Web UI                                     | host              |
+| port            | Yes      | Port of Transmission Web UI                                     | port              |
+| user            | No       | Username for Transmission Web UI                                | username          |
+| password        | No       | Password for Transmission Web UI                                | password          |
+| value_template  | Yes      | Jinja template for how the returned data from API is displayed. | jinja template    |
+
+<br />
+###### **Available fields for value_template**
+
+* downloadSpeed
+* uploadSpeed
+* activeTorrentCount
+* pausedTorrentCount
+* torrentCount
+
+> **Working example:**
+>```ini
+> [transmission-data]
+> platform = transmission
+> host = 192.168.1.30
+> port = 9091
+> user = admin
+> password = password123
+> value_template = 🔽 {{(downloadSpeed/1024/1024)|round(2)}} MB/s<br>🔼 {{(uploadSpeed/1024/1024)|round(2)}} MB/s<br><strong>Active:</strong> {{activeTorrentCount}}<br>
+>
+> [Transmission]
+> prefix = http://
+> url = 192.168.1.30:9091
+> icon = static/images/apps/transmission.png
+> description = A Fast, Easy, and Free BitTorrent Client
+> open_in = new_tab
+> data_sources = transmission-data
+>```
+"""
+
 import json
 from flask import render_template_string
 import transmissionrpc


### PR DESCRIPTION
Branched this off of develop.  Added documentation for Transmission and PiHole including available fields for the value_template.  Also fix one little typo in the curl documentation. This addresses #9 