### PR TITLE
Add the ability to preserve case for App tags

### DIFF
--- a/config_readme.md
+++ b/config_readme.md
@@ -73,7 +73,7 @@ groups = admin_only
 | sidebar_icon | No       | Icon for the sidenav.                                                                                                               | /static/images/icons/yourpicture.png, external link to image |
 | description  | No       | A short description for the app.                                                                                                    | string                                                       |
 | data_sources | No       | Data sources to be included on the app's card.*Note: you must have a data source set up in the config above this application entry. | comma separated string                                       |
-| tags         | No       | Optionally specify tags for organization on /home                                                                                   | comma separated string                                       |
+| tags         | No       | Optionally specify tags for organization on /home. You can prepend the tag with "!" to preserve case (e.g., !MEDIA), otherwise the tag will default to normal capitalization (e.g., Media)                                                                                   | comma separated string                                       |
 | groups       | No       | Optionally the access groups that can see this app.                                                                                 | comma separated string                                       |
 
 ##### Access Groups

--- a/dashmachine/main/read_config.py
+++ b/dashmachine/main/read_config.py
@@ -74,8 +74,6 @@ def read_config():
                 "custom_app_title", "DashMachine"
             )
 
-            settings.sidebar_default = config["Settings"].get("sidebar_default", "open")
-
             db.session.add(settings)
             db.session.commit()
 
@@ -84,10 +82,6 @@ def read_config():
             user = User()
             user.username = section
             user.role = config[section]["role"]
-            user.sidebar_default = config[section].get("sidebar_default", None)
-            user.home_view_mode = config[section].get("home_view_mode", "grid")
-            user.theme = config[section].get("theme", None)
-            user.accent = config[section].get("accent", None)
             user.password = ""
             if not User.query.filter_by(role="admin").first() and user.role != "admin":
                 print(
@@ -187,13 +181,19 @@ def read_config():
                 app.groups = None
 
             if "tags" in config[section]:
-                app.tags = config[section]["tags"].title()
-                for tag in app.tags.split(","):
-                    tag = tag.strip().title()
+                app_tags = []
+                for tag in config[section]["tags"].split(","):
+                    tag = tag.strip()
+                    if not tag[0] == "!":
+                        tag = tag.title()
+                    else:
+                        tag = tag.strip("!")
+                    app_tags.append(tag)
                     if not Tags.query.filter_by(name=tag).first():
                         tag_db = Tags(name=tag)
                         db.session.add(tag_db)
                         db.session.commit()
+                app.tags = ','.join(map(str, app_tags))
             else:
                 if Tags.query.first():
                     app.tags = "Untagged"


### PR DESCRIPTION
Hello, this was a minor annoyance for me so I took a stab at fixing it.  When defining tags, if you specify a "!" at the beginning it will preserve case rather than making it capitalized.  So if I would like to use MEDIA instead of Media, I can do that by setting `tags = !MEDIA` on an app.  Thanks!