### PR TITLE
0.5 revision 3

### DIFF
--- a/dashmachine/main/routes.py
+++ b/dashmachine/main/routes.py
@@ -48,20 +48,14 @@ def home():
 
 
 @main.route("/app_view?<app_id>", methods=["GET"])
-@main.route("/app_view?<url>", methods=["GET"])
-def app_view(app_id, url=None):
+def app_view(app_id):
     settings = Settings.query.first()
     if not check_groups(settings.home_access_groups, current_user):
         return redirect(url_for("user_system.login"))
-
-    if url:
-        title = url
-
-    if not url:
-        app_db = Apps.query.filter_by(id=app_id).first()
-        url = f"{app_db.prefix}{app_db.url}"
-        title = app_db.name
-    return render_template("main/app-view.html", url=url, title=title)
+    app_db = Apps.query.filter_by(id=app_id).first()
+    return render_template(
+        "main/app-view.html", url=f"{app_db.prefix}{app_db.url}", title=app_db.name
+    )
 
 
 @main.route("/load_data_source", methods=["GET"])

--- a/dashmachine/sources.py
+++ b/dashmachine/sources.py
@@ -75,6 +75,8 @@ def process_css_sources(process_bundle=None, src=None, app_global=False):
 
 
 def tag_sort_func(e):
+    if not e.sort_pos:
+        e.sort_pos = 99999
     return e.sort_pos
 
 

--- a/dashmachine/templates/main/home.html
+++ b/dashmachine/templates/main/home.html
@@ -53,7 +53,7 @@
                                                         <i class="material-icons-outlined mr-2 theme-primary-text" style="position: relative; top: .2rem">{{ tag.icon }}</i>
                                                     {% endif %}
                                                     {{ tag.name }}
-                                                    <i class="material-icons-outlined theme-secondary-text icon-btn toggle-tag-expand-btn right" data-expanded="true">keyboard_arrow_up</i>
+                                                    <i class="material-icons-outlined theme-secondary-text icon-btn toggle-tag-expand-btn right" data-expanded="true" style="position: relative; bottom: 5px">keyboard_arrow_up</i>
                                                 </h5>
                                             </div>
                                         </div>

--- a/dashmachine/version.py
+++ b/dashmachine/version.py
@@ -1,2 +1,2 @@
 version = "v0.5"
-revision_number = "2"
+revision_number = "3"

--- a/readme_cards.md
+++ b/readme_cards.md
@@ -22,7 +22,7 @@ groups = admin_only
 | open_in      | Yes      | open the app in the current tab, an iframe or a new tab                                                                             | iframe, new_tab, this_tab                                    |
 | icon         | Yes      | Icon for the dashboard.                                                                                                             | /static/images/icons/yourpicture.png, external link to image |
 | sidebar_icon | No       | Icon for the sidenav.                                                                                                               | /static/images/icons/yourpicture.png, external link to image |
-| description  | No       | A short description for the app.                                                                                                    | string                                                       |
+| description  | No       | A short description for the app.                                                                                                    | HTML                                                       |
 | data_sources | No       | Data sources to be included on the app's card.*Note: you must have a data source set up in the config above this application entry. | comma separated string                                       |
 | tags         | No       | Optionally specify tags for organization on /home                                                                                   | comma separated string                                       |
 | groups       | No       | Optionally specify the access groups that can see this app.                                                                         | comma separated string                                       |
@@ -60,3 +60,17 @@ data_sources = my_data_source
 | data_sources      | Yes      | What data sources to display on the card.                                                    | comma separated string              |
 | tags              | No       | Optionally specify tags for organization on /home                                            | comma separated string              |
 | groups            | No       | Optionally specify the access groups that can see this app.                                  | comma separated string              |
+
+
+> **Working example:**
+>```ini
+>[test]
+>platform = curl
+>resource = https://api.myip.com
+>value_template = <div class="row center-align"><div class="col s12"><h5><i class="material-icons-outlined" style="position:relative; top: 4px;">dns</i> My IP Address</h5><span class="theme-primary-text">{{value.ip}}</span></div></div>
+>response_type = json
+>
+>[MyIp.com]
+>type = custom
+>data_sources = test
+>```

--- a/template_apps/Airsonic.ini
+++ b/template_apps/Airsonic.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/airsonic.png
+sidebar_icon = static/images/apps/airsonic.png
 description = A Free and Open Source community driven media server
 open_in = this_tab 

--- a/template_apps/Bazarr.ini
+++ b/template_apps/Bazarr.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/bazarr.png
+sidebar_icon = static/images/apps/bazarr.png
 description = A companion application to Sonarr and Radarr
 open_in = this_tab 

--- a/template_apps/Bitwarden.ini
+++ b/template_apps/Bitwarden.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/bitwarden.png
+sidebar_icon = static/images/apps/bitwarden.png
 description = A free and open-source password management service
 open_in = this_tab 

--- a/template_apps/Calibre-Web.ini
+++ b/template_apps/Calibre-Web.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/calibre-web.png
+sidebar_icon = static/images/apps/calibre-web.png
 description = Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 open_in = this_tab

--- a/template_apps/Cockpit.ini
+++ b/template_apps/Cockpit.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/cockpit-project.png
+sidebar_icon = static/images/apps/cockpit-project.png
 description = An interactive server admin interface
 open_in = iframe

--- a/template_apps/Deluge.ini
+++ b/template_apps/Deluge.ini
@@ -5,6 +5,7 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/deluge.png
+sidebar_icon = static/images/apps/deluge.png
 description = Deluge is a lightweight, Free Software, cross-platform BitTorrent client
 open_in = this_tab
 

--- a/template_apps/DokuWiki.ini
+++ b/template_apps/DokuWiki.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/dokuwiki.png
+sidebar_icon = static/images/apps/dokuwiki.png
 description = DokuWiki is a simple to use and highly versatile Open Source wiki software that does not require a database.
 open_in = this_tab

--- a/template_apps/Duplicati.ini
+++ b/template_apps/Duplicati.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/duplicati.png
+sidebar_icon = static/images/apps/duplicati.png
 description = Free backup software to store encrypted backups online
 open_in = this_tab

--- a/template_apps/Emby.ini
+++ b/template_apps/Emby.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/emby.png
+sidebar_icon = static/images/apps/emby.png
 description = Emby Server is a personal media server with apps on just about every device
 open_in = this_tab 

--- a/template_apps/Firefly-III.ini
+++ b/template_apps/Firefly-III.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/firefly_iii.png
+sidebar_icon = static/images/apps/firefly_iii.png
 description = Firefly III is a self-hosted financial manager. It can help you keep track of expenses, income, budgets and everything in between.
 open_in = this_tab

--- a/template_apps/Gitea.ini
+++ b/template_apps/Gitea.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/gitea.png
+sidebar_icon = static/images/apps/gitea.png
 description = A painless self-hosted Git service
 open_in = this_tab 

--- a/template_apps/Glances.ini
+++ b/template_apps/Glances.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/glances.png
-description = A cross-platform system monitoring tool 
+sidebar_icon = static/images/apps/glances.png
+description = A cross-platform system monitoring tool
 open_in = this_tab

--- a/template_apps/Gotify.ini
+++ b/template_apps/Gotify.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/gotify.png
+sidebar_icon = static/images/apps/gotify.png
 description = A simple server for sending and receiving messages
 open_in = this_tab 

--- a/template_apps/Grafana.ini
+++ b/template_apps/Grafana.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/grafana.png
+sidebar_icon = static/images/apps/grafana.png
 description = The open observability platform
 open_in = this_tab 

--- a/template_apps/Home Assistant.ini
+++ b/template_apps/Home Assistant.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/home-assistant.png
+sidebar_icon = static/images/apps/home-assistant.png
 description = Open source home automation that puts local control and privacy first
 open_in = this_tab 

--- a/template_apps/JDownloader.ini
+++ b/template_apps/JDownloader.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/jdownloader.png
+sidebar_icon = static/images/apps/jdownloader.png
 description = A download manager written in Java
 open_in = iframe

--- a/template_apps/Jackett.ini
+++ b/template_apps/Jackett.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/jackett.png
+sidebar_icon = static/images/apps/jackett.png
 description = API Support for your favorite torrent trackers
 open_in = this_tab 

--- a/template_apps/Jellyfin.ini
+++ b/template_apps/Jellyfin.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/jellyfin.png
+sidebar_icon = static/images/apps/jellyfin.png
 description = The Free Software Media System
 open_in = this_tab 

--- a/template_apps/Krusader.ini
+++ b/template_apps/Krusader.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/krusader.png
+sidebar_icon = static/images/apps/krusader.png
 description = Twin panel file management for your desktop
 open_in = iframe

--- a/template_apps/Lidarr.ini
+++ b/template_apps/Lidarr.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/lidarr.png
+sidebar_icon = static/images/apps/lidarr.png
 description = Looks and smells like Sonarr but made for music
 open_in = this_tab 

--- a/template_apps/Mailcow.ini
+++ b/template_apps/Mailcow.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/mailcow.png
+sidebar_icon = static/images/apps/mailcow.png
 description = mailcow is a mail server suite based on Dovecot, Postfix and other open source software, that provides a modern web UI for user/server administration.
 open_in = this_tab 

--- a/template_apps/Nextcloud.ini
+++ b/template_apps/Nextcloud.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/nextcloud.png
+sidebar_icon = static/images/apps/nextcloud.png
 description = A safe home for all your data – community-driven, free & open source
 open_in = this_tab 

--- a/template_apps/Nginx Proxy Manager.ini
+++ b/template_apps/Nginx Proxy Manager.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/nginxproxymanager.png
+sidebar_icon = static/images/apps/nginxproxymanager.png
 description = Docker container for managing Nginx proxy hosts with a simple, powerful interface
 open_in = this_tab 

--- a/template_apps/Node-RED.ini
+++ b/template_apps/Node-RED.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/nodered.png
+sidebar_icon = static/images/apps/nodered.png
 description = Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways.
 open_in = this_tab 

--- a/template_apps/Ombi.ini
+++ b/template_apps/Ombi.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/ombi.png
+sidebar_icon = static/images/apps/ombi.png
 description = Want a Movie or TV Show on Plex or Emby? Use Ombi!
 open_in = this_tab 

--- a/template_apps/OpenMediaVault.ini
+++ b/template_apps/OpenMediaVault.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/openmediavault.png
+sidebar_icon = static/images/apps/openmediavault.png
 description = OpenMediaVault is the next generation network attached storage (NAS) solution based on Debian Linux.
 open_in = this_tab

--- a/template_apps/Plex.ini
+++ b/template_apps/Plex.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/plex.png
+sidebar_icon = static/images/apps/plex.png
 description = Plex is a client–server media player system and software suite.
 open_in = this_tab

--- a/template_apps/Portainer.ini
+++ b/template_apps/Portainer.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/portainer.png
+sidebar_icon = static/images/apps/portainer.png
 description = Making Docker management easy
 open_in = this_tab 

--- a/template_apps/Proxmox.ini
+++ b/template_apps/Proxmox.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/proxmox.png
+sidebar_icon = static/images/apps/proxmox.png
 description = Proxmox VE is a complete open-source platform for enterprise virtualization.
 open_in = this_tab

--- a/template_apps/Radarr.ini
+++ b/template_apps/Radarr.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/radarr.png
+sidebar_icon = static/images/apps/radarr.png
 description = A fork of Sonarr to work with movies à la Couchpotato
 open_in = this_tab 

--- a/template_apps/Riot.ini
+++ b/template_apps/Riot.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/riot.png
+sidebar_icon = static/images/apps/riot.png
 description = A glossy Matrix collaboration client for the web
 open_in = this_tab 

--- a/template_apps/SSH.ini
+++ b/template_apps/SSH.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/terminal.png
+sidebar_icon = static/images/apps/terminal.png
 description = SSH, terminal, shell, shellinabox
 open_in = this_tab 

--- a/template_apps/Sonarr.ini
+++ b/template_apps/Sonarr.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/sonarr.png
+sidebar_icon = static/images/apps/sonarr.png
 description = Smart PVR for newsgroup and bittorrent users
 open_in = this_tab 

--- a/template_apps/Syncthing.ini
+++ b/template_apps/Syncthing.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/Syncthing.png
+sidebar_icon = static/images/apps/Syncthing.png
 description = Open Source Continuous File Synchronization
 open_in = this_tab

--- a/template_apps/TasmoAdmin.ini
+++ b/template_apps/TasmoAdmin.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/tasmoadmin.png
+sidebar_icon = static/images/apps/tasmoadmin.png
 description =  Website to manage Sonoff Devices flashed with Tasmota
 open_in = this_tab 

--- a/template_apps/Tautulli.ini
+++ b/template_apps/Tautulli.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/tautulli.png
+sidebar_icon = static/images/apps/tautulli.png
 description = A Python based monitoring and tracking tool for Plex Media Server
 open_in = this_tab 

--- a/template_apps/The Lounge.ini
+++ b/template_apps/The Lounge.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/thelounge.png
+sidebar_icon = static/images/apps/thelounge.png
 description = Modern, responsive, cross-platform, self-hosted web IRC client
 open_in = this_tab 

--- a/template_apps/Traefik.ini
+++ b/template_apps/Traefik.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/traefik.png
+sidebar_icon = static/images/apps/traefik.png
 description = The Cloud Native Edge Router
 open_in = this_tab 

--- a/template_apps/Transmission.ini
+++ b/template_apps/Transmission.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/transmission.png
+sidebar_icon = static/images/apps/transmission.png
 description = A Fast, Easy, and Free BitTorrent Client
 open_in = this_tab 

--- a/template_apps/Unifi.ini
+++ b/template_apps/Unifi.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/unifi.png
+sidebar_icon = static/images/apps/unifi.png
 description = The UniFi® Controller is a wireless network management software solution from Ubiquiti Networks™. It allows you to manage multiple wireless networks using a web browser.
 open_in = this_tab

--- a/template_apps/VS Code.ini
+++ b/template_apps/VS Code.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/vscode.png
+sidebar_icon = static/images/apps/vscode.png
 description =  A code editor redefined and optimized for building and debugging modern web and cloud applications
 open_in = this_tab 

--- a/template_apps/Wikijs.ini
+++ b/template_apps/Wikijs.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/wikijs.png
+sidebar_icon = static/images/apps/wikijs.png
 description = A modern, lightweight and powerful wiki app built on Node.js
 open_in = this_tab

--- a/template_apps/qBittorrent.ini
+++ b/template_apps/qBittorrent.ini
@@ -2,5 +2,6 @@
 prefix = https://
 url = your-website.com
 icon = static/images/apps/qbittorrent.png
+sidebar_icon = static/images/apps/qbittorrent.png
 description = A BitTorrent client in Qt
 open_in = iframe


### PR DESCRIPTION
-fixed issue I've been dealing with concerning untagged apps
- they now show up as 'untagged'
- centered dropdown icon on tag headers
- added example for custom cards
- highlighted that HTML can now be used in the description field for apps.
- added sidebar_icon for all template apps, because if it's blank now, it doesnt show up on the sidebar.
- reverted experiment that was supposed to never be saved, but broke iframes
- fixes #75 for real this time
- fixes #79 