### PR TITLE
fix rest platform headers not working

### DIFF
--- a/dashmachine/platform/rest.py
+++ b/dashmachine/platform/rest.py
@@ -59,6 +59,8 @@ class Platform:
     def __init__(self, *args, **kwargs):
         # parse the user's options from the config entries
         for key, value in kwargs.items():
+            if key == "headers":
+                value = json.loads(value)
             self.__dict__[key] = value
 
         # set defaults for omitted options


### PR DESCRIPTION
headers were of type str, but requests.get expects a dict.
This deserializes the headers argument from str to dict (via json).

Fixes #90 