### PR TITLE
disable interpolation for config reader

### DIFF
--- a/dashmachine/main/read_config.py
+++ b/dashmachine/main/read_config.py
@@ -22,7 +22,7 @@ def row2dict(row):
 
 
 def read_config():
-    config = ConfigParser()
+    config = ConfigParser(interpolation=None)
     try:
         config.read(os.path.join(user_data_folder, "config.ini"))
     except Exception as e:


### PR DESCRIPTION
This caused strings whith the '%' character in it to be interpreted by Python's ConfigParser. This behavior is not needed for DashMachine, the goal is to read exactly what the user types.

Setting interpolation to None fixes this.

> With interpolation set to None, the parser would simply return %(my_dir)s/Pictures as the value of my_pictures and %(home_dir)s/lumberjack as the value of my_dir.

https://docs.python.org/3/library/configparser.html?highlight=configparser#interpolation-of-values

Fixes #56 and #89 