### PR TITLE
Added ssl_ignore attribute to http_status platform

### DIFF
--- a/dashmachine/platform/http_status.py
+++ b/dashmachine/platform/http_status.py
@@ -63,7 +63,9 @@ class Platform:
             self.headers = None
         if not hasattr(self, "return_codes"):
             self.return_codes = "2xx,3xx"
-
+        if not hasattr(self, "ssl_ignore"):
+            self.ssl_ignore = "No"
+            
     def process(self):
         # Check if method is within allowed methods for http_status
         if self.method.upper() not in ["GET", "HEAD", "OPTIONS", "TRACE"]:
@@ -84,6 +86,10 @@ class Platform:
             self.method.upper(), self.resource, headers=self.headers, auth=auth
         )
         prepped = req.prepare()
+        if self.ssl_ignore == "yes":
+            resp = s.send(prepped,verify=False)
+        else:
+            resp = s.send(prepped)
         resp = s.send(prepped)
 
         return_codes = tuple([x.replace("x", "") for x in self.return_codes.split(",")])


### PR DESCRIPTION
Added ssl_ignore attribute to platform to allow users to ignore self-signed or other SSL errors. Defaults to SSL verification ON

# [X] I'm ~~submitting~~ editing a platform
- [X] I looked at the original platform and followed a very similar methodology.
- [X] I maintained the docstring at the top of the existing platform file that is formatted exactly like rest.py
- [ ] I added sample code to any template app that this platform works for, look at deluge.ini in /template_apps/ for an example
- [X] I have thoroughly tested this platform and it works
- [ ] I am committed to updating this platform if something breaks it in the future


### Info on changes
I needed to ignore the SSL errors generated when doing an HTTP check on some of my self hosted apps i run locally that have self-signed certs. I did NOT wish to lose the SSL verification check on ALL services I had on my dashboard, so I went ahead and made some changes to the http_status platform.

I did NOT check the example code box, because I could not reliably figure out how / where to edit the "data sources" section text or any other text really for that matter (im bad with templating in pytthon).

I did NOT check the maintenance box because, well, i cant. Trust me, you don't want me messing with the code long term. I am hoping these 4 or 5 lines are helpful, but it took me many hours to get just these few lines working. 