### PR TITLE
Dont limit searchresults for apps

### DIFF
--- a/dashmachine/static/js/settings_system/settings.js
+++ b/dashmachine/static/js/settings_system/settings.js
@@ -48,8 +48,8 @@ $( document ).ready(function() {
     });
 
     $("#templates-filter").autocomplete({
-        limit: 16,
         data: autocomplete_data,
+        minLength: 0,
         onAutocomplete: function () {
             $.ajax({
                 url: $("#templates-filter").attr('data-url'),


### PR DESCRIPTION
This takes the guesswork out of the searchbar, so a user can directly see which apps are available