### PR TITLE
Remove max-height to stop scrollbar from showing on very wide monitors.

### DIFF
--- a/dashmachine/templates/main/macros.html
+++ b/dashmachine/templates/main/macros.html
@@ -14,7 +14,7 @@
     <div class="col s12 m6 l4 xl3 app-card">
         <div class="card theme-surface-transparent">
             {{ AppAnchor(app) }}
-                <div class="card-content center-align scrollbar pt-3 pb-0" style="max-height: 86px; min-height: 86px; scrollbar-width: none;">
+                <div class="card-content center-align scrollbar pt-3 pb-0" style="min-height: 86px; scrollbar-width: none;">
                     {% if app.data_sources.count() > 0 %}
                         <div class="row">
                             <div class="col s6 center-align">


### PR DESCRIPTION
On Wide monitors the max-height causes the card to be scrollable, which looks and feels bad.
Removing this seems to fix the issue in Chromium and Firefox.