### PR TITLE
Add available fields in Deluge platform

### DIFF
--- a/dashmachine/platform/deluge.py
+++ b/dashmachine/platform/deluge.py
@@ -19,6 +19,20 @@ password = MySecretPassword
 | value_template  | Yes      | Jinja template for how the returned data from api is displayed. | jinja template    |
 | password        | No       | Password to use for auth.                                       | string            |
 
+<br />
+###### **Available fields for value_template**
+* upload_rate
+* download_rate
+* max_upload
+* max_download
+* upload_protocol_rate
+* download_protocol_rate
+* num_connections
+* max_num_connections
+* dht_nodes
+* free_space
+* has_incoming_connections
+
 > **Working example:**
 >```
 >[deluge]


### PR DESCRIPTION
I've updated the deluge platform to show more available fields to the user, similar to how it is for the PiHole platform. I've pulled the fields directly from the "stats" dictionary. 

These fields are not easy to find on Google. I think this will help most users, so they don't have to use Postman to find all of the fields.

While researching, I also noticed more fields under "result", not under "stats", such as "state", which shows the amount of torrents downloading, seeding, active, paused, etc, which might be a useful statistic?