### PR TITLE
Add Dockerfile for arm

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,19 @@
+FROM python:3.8-slim
+
+RUN apt-get update -q \
+  && apt-get install --no-install-recommends -qy \
+    inetutils-ping libffi-dev build-essential libjpeg-dev zlib1g-dev libtiff-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY [ "requirements.txt", "/dashmachine/" ]
+
+WORKDIR /dashmachine
+
+RUN pip install --no-cache-dir --progress-bar off -r requirements.txt
+
+COPY [ ".", "/dashmachine/" ]
+
+ENV PRODUCTION=true
+EXPOSE 5000
+VOLUME /dashmachine/dashmachine/user_data
+CMD [ "gunicorn", "--bind", "0.0.0.0:5000", "wsgi:app" ]


### PR DESCRIPTION
Adds a Dockerfile for arm. It seems the base python image is different for amd64 and arm. So I added required dependencies to the Dockerfile to build an arm image.
