### PR TITLE
changing CMD (as not working in kubernetes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY [ ".", "/dashmachine/" ]
 ENV PRODUCTION=true
 EXPOSE 5000
 VOLUME /dashmachine/dashmachine/user_data
-CMD [ "gunicorn", "--bind", "0.0.0.0:5000", "wsgi:app" ]
+CMD [ "python", "run.py" ]


### PR DESCRIPTION
# [ ] I'm submitting a template app
- [ ] I have added a .ini file to DashMachine with the same name used for [App Name] in the .ini file (e.g. 'App Name.ini')
- [ ] My .ini has the exact format as the others in the folder, only changing the name, icon location, and description.
- [ ] I used the official description and name for the app, found on their repository/website.
- [ ] I chose an icon (.png file) sized over 64px, with a transparent background, square aspect ratio, preferably the icon only version (not icon w/ text) of the app's icon.
- [ ] I understand that the icon will be resized to 64px x 64px and have verified that it looks good at that size.
- [ ] I have added the icon to static/images/apps with the correct name matching what's in the .ini.
- [ ] I tested it to make sure it looks good in the interface

# [X ] I'm submitting a platform
- [ X] I looked at the other platform examples and followed a very similar methodology.
- [ X] I added a docstring at the top of my platform file that is formatted exactly like rest.py
- [ X] I added sample code to any template app that this platform works for, look at deluge.ini in /template_apps/ for an example
- [ X] I have thoroughly tested this platform and it works
- [ X] I am committed to updating this platform if something breaks it in the future