### PR TITLE
Update plex.py

### DIFF
--- a/dashmachine/platform/plex.py
+++ b/dashmachine/platform/plex.py
@@ -4,7 +4,7 @@ Connect to Plex Media Server and see current sessions details
 ```ini
 [variable_name]
 platform = plex
-url = http://plex_host:plex_port
+host = http://plex_host:plex_port
 token = plex_token
 value_template = {{ value_template }}
 ```


### PR DESCRIPTION
correction to the format of the data source for plex. in the beginning of the file it states 'url' instead of 'host' which shows the wrong info in the right info pane and also breaks the data source.

changing it to 'host' fixes the issue, the correct information is shown in the right info pane and the data source works correctly.

# [ ] I'm submitting a template app
- [ ] I have added a .ini file to DashMachine with the same name used for [App Name] in the .ini file (e.g. 'App Name.ini')
- [ ] My .ini has the exact format as the others in the folder, only changing the name, icon location, and description.
- [ ] I used the official description and name for the app, found on their repository/website.
- [ ] I chose an icon (.png file) sized over 64px, with a transparent background, square aspect ratio, preferably the icon only version (not icon w/ text) of the app's icon.
- [ ] I understand that the icon will be resized to 64px x 64px and have verified that it looks good at that size.
- [ ] I have added the icon to static/images/apps with the correct name matching what's in the .ini.
- [ ] I tested it to make sure it looks good in the interface

# [x] I'm submitting a platform
- [ ] I looked at the other platform examples and followed a very similar methodology.
- [ ] I added a docstring at the top of my platform file that is formatted exactly like rest.py
- [ ] I added sample code to any template app that this platform works for, look at deluge.ini in /template_apps/ for an example
- [x] I have thoroughly tested this platform and it works
- [ ] I am committed to updating this platform if something breaks it in the future