### PR TITLE
Platform Fixes / Updates: Lidarr, Sonarr, Radarr

### DIFF
--- a/dashmachine/platform/lidarr.py
+++ b/dashmachine/platform/lidarr.py
@@ -77,6 +77,9 @@ class Lidarr(object):
         self.version = "?"
         self.wanted_missing = 0
         self.wanted_cutoff = 0
+        self.artists = 0
+        self.albums = 0
+        self.tracks = 0
         self.queue = 0
         self.diskspace = [
             {"path": "", "total": "", "free": "", "used": ""},
@@ -133,6 +136,81 @@ class Lidarr(object):
 
         if rawdata != None:
             self.version = rawdata["version"]
+
+    def getArtists(self):
+        verify = (
+            False
+            if str(self.verify).lower() == "false"
+            or str(self.prefix).lower() == "http://"
+            else True
+        )
+        headers = {"X-Api-Key": self.api_key}
+        port = "" if self.port == None else ":" + self.port
+
+        if self.method.upper() == "GET":
+            try:
+                rawdata = requests.get(
+                    self.prefix + self.host + port + self.endpoint + "/artist",
+                    headers=headers,
+                    verify=verify,
+                    timeout=10,
+                ).json()
+            except Exception as e:
+                rawdata = None
+                self.error = f"{e}"
+
+        if rawdata != None:
+            self.artists = len(rawdata)
+
+    def getAlbums(self):
+        verify = (
+            False
+            if str(self.verify).lower() == "false"
+            or str(self.prefix).lower() == "http://"
+            else True
+        )
+        headers = {"X-Api-Key": self.api_key}
+        port = "" if self.port == None else ":" + self.port
+
+        if self.method.upper() == "GET":
+            try:
+                rawdata = requests.get(
+                    self.prefix + self.host + port + self.endpoint + "/album",
+                    headers=headers,
+                    verify=verify,
+                    timeout=10,
+                ).json()
+            except Exception as e:
+                rawdata = None
+                self.error = f"{e}"
+
+        if rawdata != None:
+            self.artists = len(rawdata)
+
+    def getTracks(self):
+        verify = (
+            False
+            if str(self.verify).lower() == "false"
+            or str(self.prefix).lower() == "http://"
+            else True
+        )
+        headers = {"X-Api-Key": self.api_key}
+        port = "" if self.port == None else ":" + self.port
+
+        if self.method.upper() == "GET":
+            try:
+                rawdata = requests.get(
+                    self.prefix + self.host + port + self.endpoint + "/track",
+                    headers=headers,
+                    verify=verify,
+                    timeout=10,
+                ).json()
+            except Exception as e:
+                rawdata = None
+                self.error = f"{e}"
+
+        if rawdata != None:
+            self.artists = len(rawdata)
 
     def getWanted(self, wType):
         verify = (
@@ -239,6 +317,9 @@ class Lidarr(object):
         if self.error == None:
             self.error = ""
             self.getVersion()
+            self.getArtists()
+            self.getAlbums()
+            self.getTracks()
             self.getWanted("missing")
             self.getWanted("cutoff")
             self.getQueue()

--- a/dashmachine/platform/radarr.py
+++ b/dashmachine/platform/radarr.py
@@ -61,7 +61,7 @@ import requests
 
 class Radarr(object):
     def __init__(self, method, prefix, host, port, api_key, verify):
-        self.endpoint = "/api"
+        self.endpoint = "/api/v3"
         self.method = method
         self.prefix = prefix
         self.host = host
@@ -178,7 +178,7 @@ class Radarr(object):
                 self.error = f"{e}"
 
         if rawdata != None:
-            self.queue = len((rawdata))
+            self.queue = rawdata["totalRecords"]
 
     def getDiskspace(self):
         verify = (

--- a/dashmachine/platform/sonarr.py
+++ b/dashmachine/platform/sonarr.py
@@ -130,6 +130,31 @@ class Sonarr(object):
         if rawdata != None:
             self.version = rawdata["version"]
 
+    def getShows(self):
+        verify = (
+            False
+            if str(self.verify).lower() == "false"
+            or str(self.prefix).lower() == "http://"
+            else True
+        )
+        headers = {"X-Api-Key": self.api_key}
+        port = "" if self.port == None else ":" + self.port
+
+        if self.method.upper() == "GET":
+            try:
+                rawdata = requests.get(
+                    self.prefix + self.host + port + self.endpoint + "/series",
+                    headers=headers,
+                    verify=verify,
+                    timeout=10,
+                ).json()
+            except Exception as e:
+                rawdata = None
+                self.error = f"{e}"
+
+        if rawdata != None:
+            self.shows = len(rawdata)
+
     def getWanted(self):
         verify = (
             False
@@ -226,6 +251,7 @@ class Sonarr(object):
         if self.error == None:
             self.error = ""
             self.getVersion()
+            self.getShows()
             self.getWanted()
             self.getQueue()
             self.getDiskspace()

--- a/dashmachine/platform/sonarr.py
+++ b/dashmachine/platform/sonarr.py
@@ -72,6 +72,7 @@ class Sonarr(object):
         # Initialize results
         self.error = None
         self.version = "?"
+        self.shows = 0
         self.wanted_missing = 0
         self.queue = 0
         self.diskspace = [


### PR DESCRIPTION
Lidarr
- Tracks count as data source variable accessible via {{ tracks }}
- Album count as data source variable accessible via {{ albums }}
- Artist count as data source variable accessible via {{ artists }}

Radarr
- Update endpoint
- Fix a bug in getQueue as modern calls to /api/v3/queue save the count of records in field "totalRecords"

Sonarr
- TV Series count as data source variable accessible via {{ shows }}